### PR TITLE
Support raw option to return the SVG as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Adds a prefix to ids to avoid collision across svg files.
 
 default: `idPrefix: false`
 
+#### `raw: boolean`
+
+Returns the content of the cleaned up SVG as a string instead of a module. Useful if you plan on passing
+the output on to file-loader, etc.
+
+default: `raw: false`
+
 <h2 align="center">Example Usage</h2>
 
 ```js

--- a/index.js
+++ b/index.js
@@ -62,7 +62,13 @@ function SVGInlineLoader(content) {
     // Configuration
     var query = loaderUtils.parseQuery(this.query);
 
-    return "module.exports = " + JSON.stringify(getExtractedSVG(content, query));
+    var extractedSVG = getExtractedSVG(content, query);
+
+    if (query.raw) {
+        return extractedSVG;
+    } else {
+        return "module.exports = " + JSON.stringify(extractedSVG);
+    }
 }
 
 SVGInlineLoader.getExtractedSVG = getExtractedSVG;


### PR DESCRIPTION
Our use case requires us to clean up our SVG assets to prepare them for inlining, but then to provide our application with a URL to the cleaned up SVG via file-loader (or url-loader).

(For those interested, [angular-material](https://github.com/angular/material)'s [$mdIconProvider](https://material.angularjs.org/latest/api/service/$mdIconProvider) accepts a URL to an SVG that must already be stripped of the xml document tag as well as any others that would prevent it from being inlined onto the DOM.)

In order to support this flow, I've added the raw option. When the raw option is enabled, svg-inline-loader returns the content of the cleaned up SVG as a string, which can then be forwarded to file-loader, url-loader, etc.

Is this something that would be considered universal enough to merged into master? If so, I'd be happy to also write a test for this new option, as well as make any other changes that would enable this pull request to be merged.