### PR TITLE
fix(PropTypes): Use package `prop-types` for React 16 compatibility

### DIFF
--- a/lib/component.jsx
+++ b/lib/component.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 var assign = require('object-assign');
 
 
@@ -16,8 +17,8 @@ var IconSVG = React.createClass({
         };
     },
     propTypes: {
-        src: React.PropTypes.string.isRequired,
-        elementName: React.PropTypes.string
+        src: PropTypes.string.isRequired,
+        elementName: PropTypes.string
     },
     render: function render() {
         var props = assign({}, this.props,


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs