### PR TITLE
Added options to define export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Adds a prefix to ids to avoid collision across svg files.
 
 default: `idPrefix: false`
 
+#### `exportAsDefault: boolean`, `exportAsEs6Default: boolean`
+
+There are different export formats available:
+
++ ```module.exports``` (default, cjs format). "Hello world" becomes ```module.exports = "Hello world";```
++ ```exports.default``` (when ```exportAsDefault``` param is set, es6to5 format). "Hello world" becomes ```exports.default = "Hello world";```
++ ```exports default``` (when ```exportAsEs6Default``` param is set, es6 format). "Hello world" becomes ```exports default "Hello world";```
+
+default: `exportAsDefault: false`
+
+default: `exportAsEs6Default: false`
+
 <h2 align="center">Example Usage</h2>
 
 ```js

--- a/config.js
+++ b/config.js
@@ -11,5 +11,7 @@ module.exports = {
     classPrefix: false,
     idPrefix: false,
     warnTags: [],
-    warnTagAttrs: []
+    warnTagAttrs: [],
+    exportAsDefault: false,
+    exportAsEs6Default: false
 };

--- a/index.js
+++ b/index.js
@@ -62,7 +62,14 @@ function SVGInlineLoader(content) {
     // Configuration
     var query = loaderUtils.parseQuery(this.query);
 
-    return "module.exports = " + JSON.stringify(getExtractedSVG(content, query));
+    var exportsString = "module.exports = ";
+    if (query.exportAsDefault) {
+        exportsString = "exports.default = ";
+    } else if (query.exportAsEs6Default) {
+        exportsString = "exports default ";
+    }
+
+    return exportsString + JSON.stringify(getExtractedSVG(content, query));
 }
 
 SVGInlineLoader.getExtractedSVG = getExtractedSVG;

--- a/tests/svg-inline-loader.test.js
+++ b/tests/svg-inline-loader.test.js
@@ -153,3 +153,22 @@ describe('getExtractedSVG()', function(){
         console.warn = oldConsoleWarn; // reset console back
     });
 });
+
+describe('SVGInlineLoader', function() {
+    var processedSVG = SVGInlineLoader.getExtractedSVG(svgWithRect);
+
+    it("should export as commonjs export", function() {
+        expect(SVGInlineLoader.call({ query: "" }, svgWithRect))
+            .to.be.eql('module.exports = ' + JSON.stringify(processedSVG));
+    });
+
+    it("should export as default export for es6to5 transpilation", function() {
+        expect(SVGInlineLoader.call({ query: "?exportAsDefault" }, svgWithRect))
+            .to.be.eql('exports.default = ' + JSON.stringify(processedSVG));
+    });
+
+    it("should export as es6 default export", function() {
+        expect(SVGInlineLoader.call({ query: "?exportAsEs6Default" }, svgWithRect))
+            .to.be.eql('exports default ' + JSON.stringify(processedSVG));
+    });
+});


### PR DESCRIPTION
Hello, there.

As I'm using ES6 imports but transpile my output to ES5, I encounter the `.default` phenomenon.
I fixed this by providing config flags, I just copied the option from html-loader and added some custom tests.

Equivalent to https://github.com/webpack-contrib/html-loader#export-formats

Regards!