### PR TITLE
Use loader context for loader interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var regexSequences = [
     [/\> \</g, "><"]                               // remove whitespace between tags
 ];
 
-function getExtractedSVG(svgStr, query) {
+function getExtractedSVG(loaderContext, svgStr, query) {
     var config;
     // interpolate hashes in classPrefix
     if(!!query) {
@@ -28,12 +28,12 @@ function getExtractedSVG(svgStr, query) {
 
         if (!!config.classPrefix) {
             const name = config.classPrefix === true ? '__[hash:base64:7]__' : config.classPrefix;
-            config.classPrefix = loaderUtils.interpolateName({}, name, { content: svgStr });
+            config.classPrefix = loaderUtils.interpolateName(loaderContext, name, { content: svgStr });
         }
 
         if (!!config.idPrefix) {
             const id_name = config.idPrefix === true ? '__[hash:base64:7]__' : config.idPrefix;
-            config.idPrefix = loaderUtils.interpolateName({}, id_name, { content: svgStr });
+            config.idPrefix = loaderUtils.interpolateName(loaderContext, id_name, { content: svgStr });
         }
     }
 
@@ -62,7 +62,7 @@ function SVGInlineLoader(content) {
     // Configuration
     var query = loaderUtils.parseQuery(this.query);
 
-    return "module.exports = " + JSON.stringify(getExtractedSVG(content, query));
+    return "module.exports = " + JSON.stringify(getExtractedSVG(this, content, query));
 }
 
 SVGInlineLoader.getExtractedSVG = getExtractedSVG;


### PR DESCRIPTION
interpolateFileName needs the loader context in order to correctly interpolate [name], [path] etc.

This change passes the context to getExtractedSVG which uses it to interpolate the name for idPrefix and classPrefix.