### PR TITLE
Prefix ids in style tags

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -116,13 +116,13 @@ function createClassPrefix(classPrefix) {
                 //Prefix classes when multiple classes are present
                 var classes = tag.attributes[classIdx][1];
                 var prefixedClassString = "";
-                
+
                 classes = classes.replace(/[ ]+/,' ');
                 classes = classes.split(' ');
                 classes.forEach(function(classI){
                     prefixedClassString += classPrefix + classI + ' ';
                 });
-                
+
                 tag.attributes[classIdx][1] = prefixedClassString;
             }
         }
@@ -131,14 +131,23 @@ function createClassPrefix(classPrefix) {
 }
 
 function createIdPrefix(idPrefix) {
-    var url_pattern = /^url\(#.+\)$/i;
+    var url_pattern = /url\(#(.+?)\)/ig;
+    var inStyleTag = false;
     return function prefixIds(tag) {
         var idIdx = getAttributeIndex(tag, 'id');
+        if (inStyleTag) {
+            tag.chars = tag.chars.replace(url_pattern, 'url(#'+idPrefix+'$1)');
+            inStyleTag = false;
+            return tag;
+        }
+        if (conditions.isStyleToken(tag)) {
+            inStyleTag = true;
+            return tag;
+        }
         if (idIdx !== -1) {
             //  prefix id definitions
             tag.attributes[idIdx][1] = idPrefix + tag.attributes[idIdx][1];
         }
-
         if (tag.tagName == 'use') {
             // replace references via <use xlink:href='#foo'>
             var hrefIdx = getAttributeIndex(tag, 'xlink:href');


### PR DESCRIPTION
This allows prefixed ids to appear within embedded styles:

```
<style>
.foo { clip-path: url(#some-id); ... }
</style>
```