### PR TITLE
Fix regexp not removing multi-line comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ var regexSequences = [
     // Remove XML stuffs and comments
     [/<\?xml[\s\S]*?>/gi, ""],
     [/<!doctype[\s\S]*?>/gi, ""],
-    [/<!--.*-->/gi, ""],
+    [/<!--[\s\S]*?-->/g, ""],
 
     // SVG XML -> HTML5
-    [/\<([A-Za-z]+)([^\>]*)\/\>/g, "<$1$2></$1>"], // convert self-closing XML SVG nodes to explicitly closed HTML5 SVG nodes
+    [/\<([a-z]+)([^\>]*)\/\>/gi, "<$1$2></$1>"], // convert self-closing XML SVG nodes to explicitly closed HTML5 SVG nodes
     [/\s+/g, " "],                                 // replace whitespace sequences with a single space
     [/\> \</g, "><"]                               // remove whitespace between tags
 ];


### PR DESCRIPTION
The previous regular expression had two issues:
1. It was only able to remove 1-line comments.
2. It was not set to be ungreedy, and could potentially remove content between two comments. E.g. when something like `<!-- comment --> content <!-- comment -->` does not contain a newline character, the content would actually be removed.

We run into this issue at https://gerrit.wikimedia.org/r/489323. As a temporary workaround we made all our comments 1-line comments, and made sure each comment is on a separate line.